### PR TITLE
Unify possible splits update logic + fix for rpf

### DIFF
--- a/src/lib/cpf.cpp
+++ b/src/lib/cpf.cpp
@@ -952,16 +952,15 @@ void ClassificationRPF::create_tree_family(std::vector<Leaf> initial_leaves, siz
           // create union of split coord, feature dim and dimensions of old tree
           std::set<int> curr_dims = curr_split.tree_index->split_dims;
           curr_dims.insert(curr_split.split_coordinate);
-          if (curr_dims.count(feature_dim) == 0)
-            curr_dims.insert(feature_dim);
+          curr_dims.insert(feature_dim);
           curr_dims.erase(0);
-
-          // do not exceed maximum level of interaction
-          if (max_interaction >= 0 && curr_dims.size() > (size_t)max_interaction)
-            continue;
 
           // skip if possible_split already exists
           if (possibleExists(feature_dim, possible_splits, curr_dims))
+            continue;
+
+          // do not exceed maximum level of interaction
+          if (max_interaction >= 0 && curr_dims.size() > (size_t)max_interaction)
             continue;
 
           // check if resulting tree already exists in family

--- a/src/lib/rpf.cpp
+++ b/src/lib/rpf.cpp
@@ -343,22 +343,18 @@ void RandomPlantedForest::create_tree_family(std::vector<Leaf> initial_leaves, s
       for (int feature_dim = 1; feature_dim <= feature_size; ++feature_dim)
       { // consider all possible dimensions
 
-        // ignore dim if same as split coordinate or in dimensions of old tree
-        if (feature_dim == curr_split.split_coordinate || curr_split.tree_index->split_dims.count(feature_dim) > 0)
-          continue;
-
         // create union of split coord, feature dim and dimensions of old tree
         std::set<int> curr_dims = curr_split.tree_index->split_dims;
         curr_dims.insert(curr_split.split_coordinate);
         curr_dims.insert(feature_dim);
         curr_dims.erase(0);
 
-        // do not exceed maximum level of interaction
-        if (max_interaction >= 0 && curr_dims.size() > (size_t)max_interaction)
-          continue;
-
         // skip if possible_split already exists
         if (possibleExists(feature_dim, possible_splits, curr_dims))
+          continue;
+
+        // do not exceed maximum level of interaction
+        if (max_interaction >= 0 && curr_dims.size() > (size_t)max_interaction)
           continue;
 
         // check if resulting tree already exists in family


### PR DESCRIPTION
The check in the regression scenario for `curr_split.tree_index->split_dims.count(feature_dim) > 0)` is incorrect. 
Assume that we have the following tree growth:

1. Ø was split wrt 1, resulting in a {1}-tree, and potential splits now include ({1,2}, 2) and ({1,3}, 3)
2. {1} was split wrt. 2 resulting in a {1,2}-tree and potential splits now include ({1,2,3}, 3) but also ({1,2}, 1)

In the current code for the regression scenario, the ({1,2}, 1) option is not included after the second split. Classification does it correctly however. 